### PR TITLE
docs: align Visual Studio Project docs with Visual Studio 2022

### DIFF
--- a/docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Custom_code/Visual_Studio_Project.mdx
+++ b/docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Custom_code/Visual_Studio_Project.mdx
@@ -22,7 +22,7 @@ _______________________________________________
 Данный кубик доступен с версии 7.3.2.0
 :::
 
-Экшен **“Проект Visual Studio”** позволяет использовать в проекте ZennoPoster проект созданный в среде Microsoft Visual Studio 2019 и тем самым открывает неограниченные возможности для написания, отладки кода и подключения внешних библиотек.
+Экшен **“Проект Visual Studio”** позволяет использовать в проекте ZennoPoster проект созданный в среде Microsoft Visual Studio 2022 и тем самым открывает неограниченные возможности для написания, отладки кода и подключения внешних библиотек.
 
 ## Как добавить действие в проект?
 
@@ -80,7 +80,7 @@ _______________________________________________
 
 :::warning Внимание
 Для работы экшена в режиме “Решение Visual Studio” необходимо, чтобы были установлены:
-- Visual Studio 2019. Бесплатную Community версию можно скачать на официальном сайте https://visualstudio.microsoft.com/ru/vs/community/
+- Visual Studio 2022. Бесплатную Community версию можно скачать на официальном сайте https://visualstudio.microsoft.com/ru/vs/community/
 - Конечная платформа проекта для .Net Framework 4.6.2 ([Download .NET SDKs for Visual Studio (microsoft.com)](https://dotnet.microsoft.com/download/visual-studio-sdks))
 :::
 
@@ -242,11 +242,11 @@ _______________________________________________
 
 
 
-Подробное описание данной настройки доступно по ссылке: [Поддержка Per-Monitor для расширений Visual Studio](https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2019 "https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2019")
+Подробное описание данной настройки доступно по ссылке: [Поддержка Per-Monitor для расширений Visual Studio](https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2022 "https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2022")
 
 Если данная опция у вас недоступна, то следует обновить Windows и Visual Studio или можно воспользоваться инструкцией по установке ключа в реестре:
 
-https://docs.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2019#add-a-registry-entry
+https://docs.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022#add-a-registry-entry
 
 ## Полезные ссылки
 

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Custom_code/Visual_Studio_Project.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Custom_code/Visual_Studio_Project.mdx
@@ -21,7 +21,7 @@ _______________________________________________
 This block is available starting from version 7.3.2.0
 :::
 
-The **“Visual Studio Project”** action allows you to use a project created in Microsoft Visual Studio 2019 within a ZennoPoster project, opening up unlimited possibilities for writing, debugging code, and connecting external libraries.
+The **“Visual Studio Project”** action allows you to use a project created in Microsoft Visual Studio 2022 within a ZennoPoster project, opening up unlimited possibilities for writing, debugging code, and connecting external libraries.
 
 ## How do I add this action to my project?
 
@@ -79,7 +79,7 @@ Controls:
 
 :::warning Attention
 To use this action in “Visual Studio Solution” mode, you must have:
-- Visual Studio 2019 installed. You can download the free Community version from the official website: https://visualstudio.microsoft.com/ru/vs/community/
+- Visual Studio 2022 installed. You can download the free Community version from the official website: https://visualstudio.microsoft.com/ru/vs/community/
 - The target platform for the project as .Net Framework 4.6.2 ([Download .NET SDKs for Visual Studio (microsoft.com)](https://dotnet.microsoft.com/download/visual-studio-sdks))
 :::
 
@@ -233,11 +233,11 @@ To resolve the issue, check your Visual Studio settings.
 ![image-20210303-133035](./assets/Visual_Studio_Project/Visual_Studio_Project_pic20.png)
 
 
-You can find a detailed explanation of this setting here: [Per-Monitor support for Visual Studio extensions](https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2019 "https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2019")
+You can find a detailed explanation of this setting here: [Per-Monitor support for Visual Studio extensions](https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2022 "https://docs.microsoft.com/ru-ru/visualstudio/extensibility/ux-guidelines/per-monitor-awareness-extenders?view=vs-2022")
 
 If this option is unavailable, try updating Windows and Visual Studio, or follow the instructions for manually adding a registry key:
 
-https://docs.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2019#add-a-registry-entry
+https://docs.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022#add-a-registry-entry
 
 ## Useful Links
 


### PR DESCRIPTION
## Summary
Updates the ZennoPoster "Visual Studio Project" action documentation (Russian source and English translation) to reference Visual Studio 2022 instead of 2019, and aligns Microsoft Learn query parameters with `view=vs-2022`.

## Commits included
### `13418a03` — docs: update Visual Studio Project page to VS 2022 (2 files)
- **RU:** `docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Custom_code/Visual_Studio_Project.mdx` — product version and prerequisite wording; docs URLs.
- **EN:** `i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Custom_code/Visual_Studio_Project.mdx` — same scope for the translated page.

## Stats
- **2 files changed**, **8 insertions**, **8 deletions**
