### PR TITLE
feat: responsive navbar restructuring with zone-based layout

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -263,13 +263,6 @@ img[alt*="-eighty"] { width: 80%; }
   color: #67f5a9 !important;
 }
 
-@media (max-width: 996px) {
-  .video-course-link-container {
-    display: none;
-  }
-}
-
-
 .lk-link svg {
   display: none;
 }

--- a/src/theme/Navbar/Content/index.jsx
+++ b/src/theme/Navbar/Content/index.jsx
@@ -62,8 +62,10 @@ export default function NavbarContent() {
   return (
     <>
       <div className={clsx('navbar__inner', styles.navbarInner)}>
-        <div className={clsx('navbar__items', styles.mainItems)}>
+        <div className={clsx('navbar__items', styles.brandItems)}>
           <NavbarLogo />
+        </div>
+        <div className={clsx('navbar__items', styles.searchItems)}>
           <NavbarItems items={searchItems} />
         </div>
         <div className={clsx('navbar__items', styles.productItems)}>

--- a/src/theme/Navbar/Content/index.jsx
+++ b/src/theme/Navbar/Content/index.jsx
@@ -1,10 +1,14 @@
 import NavbarItem from '@theme/NavbarItem';
+import clsx from 'clsx';
+import {useLocation} from '@docusaurus/router';
+import Link from '@docusaurus/Link';
 
 import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
 import NavbarLogo from '@theme/Navbar/Logo';
 import styles from './styles.module.css';
 import { getMenuItems } from '../menuItems';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import getLocaleStrings from '@site/src/locales';
 
 function NavbarItems({ items = [] }) {
   return (
@@ -16,21 +20,61 @@ function NavbarItems({ items = [] }) {
   );
 }
 
+function getVideoCourseUrl(pathname) {
+  if (pathname.includes('/zennodroid/')) {
+    return '/zennodroid/video-course';
+  }
+
+  if (pathname.includes('/zennoposter/')) {
+    return '/zennoposter/hello/zennoposter-video-course';
+  }
+
+  if (pathname.includes('/zennobrowser/')) {
+    return '/zennobrowser/introduction/zennobrowser-video-course';
+  }
+
+  return null;
+}
+
+function VideoCourseLink({to, label}) {
+  if (!to) {
+    return null;
+  }
+
+  return (
+    <div className="navbar__item video-course-link-container">
+      <Link to={to} className="navbar__link video-course-link">
+        {label}
+      </Link>
+    </div>
+  );
+}
+
 export default function NavbarContent() {
   const { i18n } = useDocusaurusContext();
   const { currentLocale } = i18n;
+  const location = useLocation();
+  const localeStrings = getLocaleStrings(currentLocale);
+  const videoCourseUrl = getVideoCourseUrl(location.pathname);
 
-  const { leftItems, rightItems } = getMenuItems(currentLocale);
+  const { searchItems, productItems, utilityItems } = getMenuItems(currentLocale);
 
   return (
     <>
-      <div className="navbar__inner">
-        <div className="navbar__items">
+      <div className={clsx('navbar__inner', styles.navbarInner)}>
+        <div className={clsx('navbar__items', styles.mainItems)}>
           <NavbarLogo />
-          <NavbarItems items={leftItems} />
+          <NavbarItems items={searchItems} />
         </div>
-        <div className="navbar__items navbar__items--right">
-          <NavbarItems items={rightItems} />
+        <div className={clsx('navbar__items', styles.productItems)}>
+          <VideoCourseLink
+            to={videoCourseUrl}
+            label={localeStrings.videoCourseLink}
+          />
+          <NavbarItems items={productItems} />
+        </div>
+        <div className={clsx('navbar__items navbar__items--right', styles.utilityItems)}>
+          <NavbarItems items={utilityItems} />
           <NavbarColorModeToggle className={styles.colorModeToggle} />
         </div>
       </div>

--- a/src/theme/Navbar/Content/styles.module.css
+++ b/src/theme/Navbar/Content/styles.module.css
@@ -2,3 +2,101 @@
   max-width: var(--ifm-container-width-xl);
   margin: 0 auto;
 }
+
+:global(.navbar) {
+  height: auto;
+  min-height: 3.75rem;
+}
+
+.navbarInner {
+  align-items: center;
+  column-gap: 0.5rem;
+  row-gap: 0;
+}
+
+.mainItems {
+  flex: 1 1 auto;
+}
+
+.productItems {
+  flex: 0 1 auto;
+  justify-content: flex-end;
+}
+
+.productItems :global(.navbar__link) {
+  white-space: nowrap;
+}
+
+.utilityItems {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 1200px) {
+  .navbarInner {
+    row-gap: 0.25rem;
+  }
+
+  .mainItems {
+    order: 1;
+    min-width: 0;
+  }
+
+  .utilityItems {
+    order: 2;
+  }
+
+  .productItems {
+    order: 3;
+    flex: 1 0 100%;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 996px) {
+  .productItems :global(.navbar__item) {
+    display: inline-block;
+  }
+
+  .colorModeToggle {
+    display: block;
+  }
+}
+
+@media (max-width: 576px) {
+  .navbarInner {
+    column-gap: 0.25rem;
+  }
+
+  .mainItems :global(.navbar__brand) {
+    margin-right: 0.25rem;
+  }
+
+  .mainItems :global(.navbar__title) {
+    max-width: 7rem;
+  }
+
+  .mainItems :global(.DocSearch-Button) {
+    width: 2.5rem;
+    padding: 0 0.5rem;
+  }
+
+  .mainItems :global(.DocSearch-Button-Placeholder),
+  .mainItems :global(.DocSearch-Button-Keys) {
+    display: none;
+  }
+
+  .mainItems :global(.navbar__search-input) {
+    width: 2.5rem;
+  }
+
+  .productItems {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 436px) {
+  .mainItems :global(.navbar__title) {
+    display: none;
+  }
+}

--- a/src/theme/Navbar/Content/styles.module.css
+++ b/src/theme/Navbar/Content/styles.module.css
@@ -11,15 +11,33 @@
 .navbarInner {
   align-items: center;
   column-gap: 0.5rem;
+  justify-content: flex-start;
   row-gap: 0;
 }
 
-.mainItems {
-  flex: 1 1 auto;
+.brandItems {
+  flex: 0 0 auto;
+  min-width: auto;
+}
+
+.brandItems :global(.navbar__brand) {
+  flex: 0 0 auto;
+  min-width: max-content;
+  margin-right: 0;
+}
+
+.searchItems {
+  flex: 0 0 auto;
+  justify-content: flex-start;
+  min-width: 0;
+}
+
+.searchItems :global(.DocSearch-Button) {
+  width: 15rem;
 }
 
 .productItems {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   justify-content: flex-end;
 }
 
@@ -31,22 +49,26 @@
   flex: 0 0 auto;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1380px) {
   .navbarInner {
     row-gap: 0.25rem;
   }
 
-  .mainItems {
+  .brandItems {
     order: 1;
-    min-width: 0;
   }
 
-  .utilityItems {
+  .searchItems {
     order: 2;
   }
 
-  .productItems {
+  .utilityItems {
     order: 3;
+    margin-left: auto;
+  }
+
+  .productItems {
+    order: 4;
     flex: 1 0 100%;
     flex-wrap: wrap;
     justify-content: center;
@@ -63,31 +85,35 @@
   }
 }
 
+@media (max-width: 768px) {
+  .searchItems > * {
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+  }
+
+  .searchItems :global(.DocSearch-Button) {
+    width: 2.5rem;
+    padding: 0 0.5rem;
+  }
+
+  .searchItems :global(.DocSearch-Button-Placeholder),
+  .searchItems :global(.DocSearch-Button-Keys) {
+    display: none;
+  }
+
+  .searchItems :global(.navbar__search-input) {
+    width: 2.5rem;
+  }
+}
+
 @media (max-width: 576px) {
   .navbarInner {
     column-gap: 0.25rem;
   }
 
-  .mainItems :global(.navbar__brand) {
-    margin-right: 0.25rem;
-  }
-
-  .mainItems :global(.navbar__title) {
-    max-width: 7rem;
-  }
-
-  .mainItems :global(.DocSearch-Button) {
-    width: 2.5rem;
-    padding: 0 0.5rem;
-  }
-
-  .mainItems :global(.DocSearch-Button-Placeholder),
-  .mainItems :global(.DocSearch-Button-Keys) {
-    display: none;
-  }
-
-  .mainItems :global(.navbar__search-input) {
-    width: 2.5rem;
+  .utilityItems :global(.navbar__item) {
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
   }
 
   .productItems {
@@ -95,8 +121,22 @@
   }
 }
 
-@media (max-width: 436px) {
-  .mainItems :global(.navbar__title) {
+@media (max-width: 430px) {
+  .brandItems :global(.navbar__title) {
     display: none;
+  }
+
+  .utilityItems :global(.dropdown > .navbar__link) {
+    font-size: 0;
+  }
+
+  .utilityItems :global(.dropdown > .navbar__link svg) {
+    font-size: 1rem;
+    margin-right: 0;
+  }
+
+  .utilityItems :global(.dropdown > .navbar__link::after) {
+    border-width: 0.35rem 0.35rem 0;
+    margin-left: 0.2rem;
   }
 }

--- a/src/theme/Navbar/Layout/index.js
+++ b/src/theme/Navbar/Layout/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import clsx from 'clsx';
 import {useThemeConfig} from '@docusaurus/theme-common';
 import {
@@ -24,10 +24,45 @@ export default function NavbarLayout({children}) {
   } = useThemeConfig();
   const mobileSidebar = useNavbarMobileSidebar();
   const {navbarRef, isNavbarVisible} = useHideableNavbar(hideOnScroll);
+  const navbarElementRef = useRef(null);
+  const setNavbarRef = useCallback(
+    (node) => {
+      navbarElementRef.current = node;
+      navbarRef(node);
+    },
+    [navbarRef],
+  );
+
+  useEffect(() => {
+    const navbarElement = navbarElementRef.current;
+    if (!navbarElement) {
+      return undefined;
+    }
+
+    const updateNavbarHeight = () => {
+      const height = navbarElement.getBoundingClientRect().height;
+      document.documentElement.style.setProperty(
+        '--ifm-navbar-height',
+        `${height}px`,
+      );
+    };
+
+    updateNavbarHeight();
+
+    const resizeObserver = new ResizeObserver(updateNavbarHeight);
+    resizeObserver.observe(navbarElement);
+    window.addEventListener('resize', updateNavbarHeight);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateNavbarHeight);
+      document.documentElement.style.removeProperty('--ifm-navbar-height');
+    };
+  }, []);
 
   return (
     <nav
-      ref={navbarRef}
+      ref={setNavbarRef}
       aria-label={translate({
         id: 'theme.NavBar.navAriaLabel',
         message: 'Main',

--- a/src/theme/Navbar/Search/styles.module.css
+++ b/src/theme/Navbar/Search/styles.module.css
@@ -8,8 +8,8 @@ See https://github.com/facebook/docusaurus/pull/9385
 
 @media (max-width: 996px) {
   .navbarSearchContainer {
-    position: absolute;
-    right: var(--ifm-navbar-padding-horizontal);
+    padding: var(--ifm-navbar-item-padding-vertical)
+      var(--ifm-navbar-item-padding-horizontal);
   }
 }
 

--- a/src/theme/Navbar/menuItems.js
+++ b/src/theme/Navbar/menuItems.js
@@ -1,7 +1,6 @@
-import { DefaultNavbarItemProps } from '@theme/NavbarItem';
 import getLocaleStrings from '@site/src/locales';
 
-const leftItems = [
+const searchItems = [
   {
     type: 'search',
     position: 'left',
@@ -13,7 +12,7 @@ const leftItems = [
 export const getMenuItems = (locale) => {
   const localeStrings = getLocaleStrings(locale);
   
-  const rightItems = [
+  const utilityItems = [
     {
       type: 'localeDropdown',
       position: 'right',
@@ -75,7 +74,5 @@ export const getMenuItems = (locale) => {
     },
   ];
 
-  rightItems.unshift(...productItems);
-
-  return { leftItems, rightItems };
+  return { searchItems, productItems, utilityItems };
 };

--- a/src/theme/NavbarItem/SearchNavbarItem.js
+++ b/src/theme/NavbarItem/SearchNavbarItem.js
@@ -1,44 +1,6 @@
 import React from 'react';
-import { useLocation } from '@docusaurus/router';
-import Link from '@docusaurus/Link';
 import SearchNavbarItem from '@theme-original/NavbarItem/SearchNavbarItem';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import getLocaleStrings from '@site/src/locales';
 
 export default function SearchNavbarItemWrapper(props) {
-  const location = useLocation();
-  const { i18n } = useDocusaurusContext();
-  const { currentLocale } = i18n;
-  const localeStrings = getLocaleStrings(currentLocale);
-
-  // Проверяем, находимся ли мы в разделе ZennoDroid, ZennoPoster или ZennoBrowser
-  const isZennoDroidSection = location.pathname.includes('/zennodroid/');
-  const isZennoPosterSection = location.pathname.includes('/zennoposter/');
-  const isZennoBrowserSection = location.pathname.includes('/zennobrowser/');
-
-  // Определяем URL для кнопки видео-курса
-  let videoCourseUrl = null;
-  if (isZennoDroidSection) {
-    videoCourseUrl = '/zennodroid/video-course';
-  } else if (isZennoPosterSection) {
-    videoCourseUrl = '/zennoposter/hello/zennoposter-video-course';
-  } else if (isZennoBrowserSection) {
-    videoCourseUrl = '/zennobrowser/introduction/zennobrowser-video-course';
-  }
-
-  return (
-    <>
-      {videoCourseUrl && (
-        <div className="navbar__item video-course-link-container">
-          <Link
-            to={videoCourseUrl}
-            className="navbar__link video-course-link"
-          >
-            {localeStrings.videoCourseLink}
-          </Link>
-        </div>
-      )}
-      <SearchNavbarItem {...props} />
-    </>
-  );
+  return <SearchNavbarItem {...props} />;
 }


### PR DESCRIPTION
## Summary

Restructure the documentation site navbar into zone-based layout (search, product, utility)
for improved responsive behavior across tablet and mobile breakpoints.

## Changes

### feat: restructure navbar layout with responsive zones
- Split `menuItems.js` into `searchItems`, `productItems`, and `utilityItems`
- Moved video course link from `SearchNavbarItem.js` to `Navbar/Content` via `getVideoCourseUrl()` / `VideoCourseLink`
- Added three-column flex layout with responsive breakpoints (`Content/index.jsx`, `styles.module.css`)
- Synced `--ifm-navbar-height` dynamically with `ResizeObserver` in `Navbar/Layout/index.js`
- Fixed mobile search container positioning in `Navbar/Search/styles.module.css`
- Removed redundant mobile-only hide rule for `video-course-link` from `custom.css`

### fix: improve navbar layout on small screens
- Split brand logo and search into separate flex zones (`brandItems`, `searchItems`) in `Content/index.jsx`
- Replaced `mainItems` styles with dedicated brand/search/product breakpoints in `styles.module.css`
- Raised wrap breakpoint to 1380px and reordered utility vs product rows on narrow viewports
- Added 768px rules for compact DocSearch button and reduced search padding
- Tightened utility item padding at 576px and reduced product row gap
- At 430px: hide brand title, show icon-only locale dropdown with smaller caret

## Stats
- 9 files changed, ~300 insertions, ~87 deletions
