### PR TITLE
docs(zennoposter): add short slugs for ProjectMaker AI and Send Mail pages

### DIFF
--- a/docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/AI/AI_Agent.mdx
+++ b/docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/AI/AI_Agent.mdx
@@ -3,6 +3,7 @@ sidebar_position: 1
 title: "ИИ Агент"
 description: "Экшен для работы с LLM-провайдерами: отправка промптов и получение ответов в переменную."
 date: "2026-05-19"
+slug: PM_Editor_Actions_AIServices
 ---
 
 ## Описание

--- a/docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Mail/Mail_send/Send_mail.mdx
+++ b/docs/ZennoPoster/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Mail/Mail_send/Send_mail.mdx
@@ -6,6 +6,7 @@ date: "2025-08-04"
 converted: true
 originalFile: "Отправить почту.txt"
 targetUrl: "https://zennolab.atlassian.net/wiki/spaces/RU/pages/1399914500"
+slug: PM_Editor_Actions_SendMail
 ---
 import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
 

--- a/docs/ZennoPoster/ProjectMaker/ProjectMaker Settings/AI_PM.mdx
+++ b/docs/ZennoPoster/ProjectMaker/ProjectMaker Settings/AI_PM.mdx
@@ -3,6 +3,7 @@ sidebar_position: 8
 title: "ИИ"
 description: ""
 date: "2026-05-20"
+slug: PM_Settings_AIServices
 ---
 
 _______________________________________________

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/AI/AI_Agent.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/AI/AI_Agent.mdx
@@ -3,6 +3,7 @@ sidebar_position: 1
 title: "AI Agent"
 description: "Action for working with LLM providers: send prompts and receive responses into a variable."
 date: "2026-05-20"
+slug: PM_Editor_Actions_AIServices
 ---
 
 ## Description

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Mail/Mail_send/Send_mail.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/Project-editor/Actions-in-ProjectMaker-Actions-Blocks/Mail/Mail_send/Send_mail.mdx
@@ -6,6 +6,7 @@ date: "2025-08-04"
 converted: true
 originalFile: "Отправить почту.txt"
 targetUrl: "https://zennolab.atlassian.net/wiki/spaces/RU/pages/1399914500"
+slug: PM_Editor_Actions_SendMail
 ---
 import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
 

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/ProjectMaker Settings/AI_PM.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ProjectMaker/ProjectMaker Settings/AI_PM.mdx
@@ -3,6 +3,7 @@ sidebar_position: 8
 title: "AI"
 description: ""
 date: "2026-05-20"
+slug: PM_Settings_AIServices
 ---
 
 _______________________________________________


### PR DESCRIPTION
## Summary

Adds short `slug` values to three ProjectMaker pages (RU + EN) for stable deep links.

**Stats:** 1 commit · 6 files · +6 / −0

## Changes

| Slug | Page |
|------|------|
| `PM_Settings_AIServices` | AI settings (`AI_PM.mdx`) |
| `PM_Editor_Actions_AIServices` | AI Agent (`AI_Agent.mdx`) |
| `PM_Editor_Actions_SendMail` | Send Email (`Send_mail.mdx`) |
