### PR TITLE
docs(zennobrowser): document default profile storage path

### DIFF
--- a/docs/ZennoBrowser/install-and-setting/Profile_storage_location.mdx
+++ b/docs/ZennoBrowser/install-and-setting/Profile_storage_location.mdx
@@ -29,7 +29,7 @@ C:\Users\{USER}\AppData\Local\ZennoLab\Profiles
 ``` 
 
 
-**Либо если вы хотите сохранять профили на диск D в папку %Name% , то добавляем:**
+**Либо если вы хотите сохранять профили на диск D в папку Name, то добавляем:**
 ```json
 { "Paths": 
     { "ProfilesRootPath": "D:/Name" } 

--- a/docs/ZennoBrowser/install-and-setting/Profile_storage_location.mdx
+++ b/docs/ZennoBrowser/install-and-setting/Profile_storage_location.mdx
@@ -9,9 +9,16 @@ import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
 # Место хранения профилей
 <DisclaimerNotice />
 
+По умолчанию профили хранятся в директории:
+```
+C:\Users\{USER}\AppData\Local\ZennoLab\Profiles
+```
+
+
 Сейчас назначение пути для хранения профилей выглядит так:
 1. Нужно создать файл `zp8.profilemanager.json` в моих документах (если файл отсутствует)
 2. Добавить секцию Paths в файл
+
 Пример:
 
 **Для сохранения в папку TWST**
@@ -25,9 +32,9 @@ import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
 **Либо если вы хотите сохранять профили на диск D в папку %Name% , то добавляем:**
 ```json
 { "Paths": 
-    { "ProfilesRootPath": "D:/%Name%" } 
+    { "ProfilesRootPath": "D:/Name" } 
 }
 ```
 :::warning **Обратите внимание**
-Что путь через проводник пишется так `D:\%Name%`,а для JSON нужно `D:/%Name%`.
+Что путь через проводник пишется так `D:\Name`,а для JSON нужно `D:/Name`.
 :::

--- a/i18n/en/docusaurus-plugin-content-docs-zennobrowser/current/install-and-setting/Profile_storage_location.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennobrowser/current/install-and-setting/Profile_storage_location.mdx
@@ -9,9 +9,15 @@ import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
 # Profile Storage Location
 <DisclaimerNotice />
 
+By default, profiles are stored in the following directory: 
+```
+C:\Users\{USER}\AppData\Local\ZennoLab\Profiles
+```
+
 Currently, setting the profile storage path works like this:
 1. You need to create a `zp8.profilemanager.json` file in your Documents (if it doesn't already exist)
 2. Add a Paths section to the file
+
 Example:
 
 **To save to the TWST folder**
@@ -22,12 +28,12 @@ Example:
 ``` 
 
 
-**Or if you want to save profiles to the D drive in the %Name% folder, add the following:**
+**Or if you want to save profiles to the D drive in the Name folder, add the following:**
 ```json
 { "Paths": 
-    { "ProfilesRootPath": "D:/%Name%" } 
+    { "ProfilesRootPath": "D:/Name" } 
 }
 ```
 :::warning **Please note**
-The path in Explorer is written as `D:\%Name%`, but for JSON you need to use `D:/%Name%`.
+The path in Explorer is written as `D:\Name`, but for JSON you need to use `D:/Name`.
 :::


### PR DESCRIPTION
## Summary

Documents the default ZennoBrowser profile storage path in RU + EN docs and clarifies the custom D drive example.

**Stats:** 3 commits · 2 files · +19 / −6

## Changes

- Added default path: `C:\Users\{USER}\AppData\Local\ZennoLab\Profiles`
- Updated RU + EN `Profile_storage_location.mdx`
- Replaced `%Name%` example with `Name` in Explorer and JSON path notes
