### PR TITLE
Fix English docs: helpdesk locale and category index translations

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs-capmonster/current/mcs/intro.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-capmonster/current/mcs/intro.mdx
@@ -9,7 +9,7 @@ import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
 ## Description.
 **Module Creation Studio (MCS)** helps you create your own CAPTCHA recognition modules that can be used immediately in **CapMonster**.  
 
-Some steps of creating a module may seem complicated at first glance. That’s why in the following articles we’ll break everything down in detail, step by step. If you still have questions after reading, feel free to ask them via [our support](https://helpdesk.zennolab.com/ru).  
+Some steps of creating a module may seem complicated at first glance. That’s why in the following articles we’ll break everything down in detail, step by step. If you still have questions after reading, feel free to ask them via [our support](https://helpdesk.zennolab.com/en-us).  
 
 [**Download the latest version of CapMonster MCS x64**](https://static.zenno.services/release/ZennoLabCapMonsterMCSx64-RU-v2.8.3.0.exe).  
 _______________________________________________

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/BlueStacks.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/BlueStacks.mdx
@@ -43,7 +43,7 @@ So, it's best to create one or more additional VMs and use those instead.
 10. Wait until the project finishes successfully. After that, the emulator will be visible in the program and ready for you to use.
 
 If the project fails at any step, try running it again.  
-If, after several tries, the template still doesn't work, contact our [Support](https://helpdesk.zennolab.com/ru/conversation/new).
+If, after several tries, the template still doesn't work, contact our [Support](https://helpdesk.zennolab.com/en-us/conversation/new).
 
 ________________________________________________
 ## Working with the emulator

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/Connection.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/Connection.mdx
@@ -73,7 +73,7 @@ Go to [**Settings → Android**](../Settings/Settings_for_Enterprise) to make su
 
 ![Emulator setup](./assets/devices_pic9.png)
 :::info **If there's nothing in the dropdown menu, hit Refresh.**
-If nothing changes, please contact [**Support**](https://helpdesk.zennolab.com/ru).
+If nothing changes, please contact [**Support**](https://helpdesk.zennolab.com/en-us).
 :::
 ### 4. Create a project or open an existing one.
 Click *"Start device"* in the **Device** window. Or use *"Select"* and *"Start"* actions.

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/WelcomeEnterprise.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/WelcomeEnterprise.mdx
@@ -18,7 +18,7 @@ The Enterprise version supports unlimited multithreading. The license lets you l
 
 | Supported Devices | Project Execution | Number of Linked PCs | Task Complexity | Demo Version Available | Our Support Level |
 | :----------------: | :------: | :----: |:----: |:----: |:----: |
-| Physical Android + BlueStacks |   Unlimited multithreading   | 3 PCs | Any |[✅](https://zennolab.com/ru/products/zennodroid/download/)   |[We always respond and help](https://helpdesk.zennolab.com/ru/conversation/new) |
+| Physical Android + BlueStacks |   Unlimited multithreading   | 3 PCs | Any |[✅](https://zennolab.com/ru/products/zennodroid/download/)   |[We always respond and help](https://helpdesk.zennolab.com/en-us/conversation/new) |
 
 This is the go-to choice for organizations where high performance and reliable automation are mission-critical.
 

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/get-started/Other_Settings.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/get-started/Other_Settings.mdx
@@ -35,7 +35,7 @@ When you minimize the app window, it will go to the tray.
 
 _______________________________________________
 ### Monitor threads status.
-This is only for collecting stats, which can be useful if you contact [support](https://helpdesk.zennolab.com/ru/conversation/new). It starts tracking the status of threads in the app.
+This is only for collecting stats, which can be useful if you contact [support](https://helpdesk.zennolab.com/en-us/conversation/new). It starts tracking the status of threads in the app.
 
 _______________________________________________
 ### Compacts the large object heap.

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/introduction/ZennoDroid.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/introduction/ZennoDroid.mdx
@@ -64,7 +64,7 @@ This is the pick for organizations where performance and reliability in automati
 | Number of licensed PCs   | 1 PC   | 3 PCs | 3 PCs |
 | Task complexity          | Simple   | Medium and complex | Any |
 | Demo version available   | [✅](https://zennolab.com/ru/products/zennodroid/download/)   | [✅](https://zennolab.com/ru/products/zennodroid/download/) | [✅](https://zennolab.com/ru/products/zennodroid/download/) |
-| Our support level        | [Always ready to help you](https://helpdesk.zennolab.com/ru/conversation/new) 🤗🚀 | [Always ready to help you](https://helpdesk.zennolab.com/ru/conversation/new) 🤗🚀 | [Always ready to help you](https://helpdesk.zennolab.com/ru/conversation/new) 🤗🚀 |
+| Our support level        | [Always ready to help you](https://helpdesk.zennolab.com/en-us/conversation/new) 🤗🚀 | [Always ready to help you](https://helpdesk.zennolab.com/en-us/conversation/new) 🤗🚀 | [Always ready to help you](https://helpdesk.zennolab.com/en-us/conversation/new) 🤗🚀 |
 _______________________________________________
 ZennoDroid unlocks a whole new level of Android automation for you. Pick your version and start building efficient solutions today.
 

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/pm/Welcome_PM.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/pm/Welcome_PM.mdx
@@ -34,7 +34,7 @@ _______________________________________________
 ### This section lets you:
 - Create a new project.
 - Open a project from file.
-- [Contact **support**](https://helpdesk.zennolab.com/ru)
+- [Contact **support**](https://helpdesk.zennolab.com/en-us)
 - Go to the [**Forum**](https://zenno.club/discussion/). There you can discuss the program, ask questions, or find useful info.
 - Watch [**Video tutorials**](https://www.youtube.com/@ZennoLabcom/playlists).
 - Open the **Help** in your browser.

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/pro-lite/WelcomeProLite.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/pro-lite/WelcomeProLite.mdx
@@ -16,7 +16,7 @@ The Lite version includes all the essential tools to create automation scripts, 
 
 | Supported devices | Project execution | Number of linked PCs | Task complexity | Demo version available | Level of our support |
 | :----------------: | :------: | :----: |:----: |:----: |:----: |
-| Virtual (MEmu, LDPlayer)|   Single-threaded   | 1 PC |Simple |[✅](https://zennolab.com/ru/products/zennodroid/download/)   |[We’ll always answer and help](https://helpdesk.zennolab.com/ru/conversation/new) |
+| Virtual (MEmu, LDPlayer)|   Single-threaded   | 1 PC |Simple |[✅](https://zennolab.com/ru/products/zennodroid/download/)   |[We’ll always answer and help](https://helpdesk.zennolab.com/en-us/conversation/new) |
 
 _______________________________________________ 
 ### ZennoDroid Pro.
@@ -31,4 +31,4 @@ The Pro version is great for any size business where you need to automate compli
 
 | Supported devices | Project execution | Number of linked PCs | Task complexity | Demo version available | Level of our support |
 | :----------------: | :------: | :----: |:----: |:----: |:----: |
-| Virtual (MEmu, LDPlayer)|   Unlimited multithreading   | 3 PCs |Medium and complex |[✅](https://zennolab.com/ru/products/zennodroid/download/)   |[We’ll always answer and help](https://helpdesk.zennolab.com/ru/conversation/new) |
+| Virtual (MEmu, LDPlayer)|   Unlimited multithreading   | 3 PCs |Medium and complex |[✅](https://zennolab.com/ru/products/zennodroid/download/)   |[We’ll always answer and help](https://helpdesk.zennolab.com/en-us/conversation/new) |

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current.json
@@ -446,6 +446,78 @@
   "sidebar.zennoposterSidebar.category.ИИ.link.generated-index.description": {
     "message": "Actions for working with LLM providers and AI services.",
     "description": "The generated-index page description for category ИИ in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Tables.link.generated-index.title": {
+    "message": "Tables",
+    "description": "The generated-index page title for category Tables in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Tables.link.generated-index.description": {
+    "message": "Actions for working with regular and Google Sheets.",
+    "description": "The generated-index page description for category Tables in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Project Delivery.link.generated-index.title": {
+    "message": "Executing projects",
+    "description": "The generated-index page title for category Project Delivery in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Project Delivery.link.generated-index.description": {
+    "message": "Starting and managing project execution: project parameters, context menu, creating a BAT file, ZennoPoster input settings.",
+    "description": "The generated-index page description for category Project Delivery in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Project Settings.link.generated-index.title": {
+    "message": "Project parameters",
+    "description": "The generated-index page title for category Project Settings in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Project Settings.link.generated-index.description": {
+    "message": "Main execution parameters: settings, stop, log, schedule planner, instances.",
+    "description": "The generated-index page description for category Project Settings in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Schedule Planner.link.generated-index.title": {
+    "message": "Schedule Planner",
+    "description": "The generated-index page title for category Schedule Planner in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.Schedule Planner.link.generated-index.description": {
+    "message": "General information, scheduler features, and the schedule debugger for automating launches.",
+    "description": "The generated-index page description for category Schedule Planner in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ProjectMaker.link.generated-index.title": {
+    "message": "ProjectMaker - An App for Creating Projects for ZennoPoster",
+    "description": "The generated-index page title for category ProjectMaker in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ProjectMaker.link.generated-index.description": {
+    "message": "A complete guide to working with ProjectMaker, a powerful tool for creating automated projects in ZennoPoster",
+    "description": "The generated-index page description for category ProjectMaker in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ZennoPoster.link.generated-index.title": {
+    "message": "ZennoPoster - an application for running projects",
+    "description": "The generated-index page title for category ZennoPoster in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ZennoPoster.link.generated-index.description": {
+    "message": "A software suite from ZennoLab for automating browser actions and SEO tasks: record and replay scripts with no coding, multithreading, work with proxies and captchas. This section includes materials on the interface, project table, and settings (including ProxyChecker).",
+    "description": "The generated-index page description for category ZennoPoster in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.История изменений ZennoPoster.link.generated-index.title": {
+    "message": "ZennoPoster Change Log",
+    "description": "The generated-index page title for category История изменений ZennoPoster in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.История изменений ZennoPoster.link.generated-index.description": {
+    "message": "Summary of releases and changes by version. Includes subsections for ZennoPoster 7 and ZennoPoster 5.",
+    "description": "The generated-index page description for category История изменений ZennoPoster in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ZennoPoster 7 — история изменений.link.generated-index.title": {
+    "message": "ZennoPoster 7 — Change History",
+    "description": "The generated-index page title for category ZennoPoster 7 — история изменений in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ZennoPoster 7 — история изменений.link.generated-index.description": {
+    "message": "Full changelog of ZennoPoster 7: new features, improvements, and fixes.",
+    "description": "The generated-index page description for category ZennoPoster 7 — история изменений in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ZennoPoster 5 — история изменений.link.generated-index.title": {
+    "message": "ZennoPoster 5 — Change History",
+    "description": "The generated-index page title for category ZennoPoster 5 — история изменений in sidebar zennoposterSidebar"
+  },
+  "sidebar.zennoposterSidebar.category.ZennoPoster 5 — история изменений.link.generated-index.description": {
+    "message": "Chronology of ZennoPoster 5 updates: key changes and fixes.",
+    "description": "The generated-index page description for category ZennoPoster 5 — история изменений in sidebar zennoposterSidebar"
   }
 }
 

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/Hello/Obtaining_Client_Status.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/Hello/Obtaining_Client_Status.mdx
@@ -38,4 +38,4 @@ To access the private sections of the forum, you need a "**Client**" status, whi
 
 4. Make sure your client status has been assigned on the forum.
 
-If something went wrong, please contact [support](https://helpdesk.zennolab.com/ru "https://helpdesk.zennolab.com/ru").
+If something went wrong, please contact [support](https://helpdesk.zennolab.com/en-us "https://helpdesk.zennolab.com/en-us").

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/Operating_Instructions.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/Operating_Instructions.mdx
@@ -78,4 +78,4 @@ After setup, use the **"Schedule Debugger"** (menu in the upper-right corner of 
 * [Debugging a Project](/zennoposter/category/debugging-projects)  
 * [Running Projects](/zennoposter/category/project-delivery)  
 * [Schedule Planner](/zennoposter/category/schedule-planner)  
-* [Technical Support](https://helpdesk.zennolab.com/en)
+* [Technical Support](https://helpdesk.zennolab.com/en-us)

--- a/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ZennoPoster/Problem_solving/Diagnostic_Report_with_Detailed_Log.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennoposter/current/ZennoPoster/Problem_solving/Diagnostic_Report_with_Detailed_Log.mdx
@@ -55,7 +55,7 @@ The path may differ on your system (different drive letter, program version, lan
 
 After diagnostics are completed, a report.zip file will be created. This file will be in the program's installation directory (it will open automatically once diagnostics finish).
 
-Please [send the resulting file to support](https://helpdesk.zennolab.com/ "https://helpdesk.zennolab.com/").
+Please [send the resulting file to support](https://helpdesk.zennolab.com/en-us "https://helpdesk.zennolab.com/en-us").
 
 </details>
 
@@ -100,7 +100,7 @@ The path may differ on your system (different drive letter, program version, lan
 
 After diagnostics are completed, a report.zip file will be created. This file will be in the program's installation directory (it will open automatically once diagnostics finish).
 
-Please [send the resulting file to support](https://helpdesk.zennolab.com/ "https://helpdesk.zennolab.com/").
+Please [send the resulting file to support](https://helpdesk.zennolab.com/en-us "https://helpdesk.zennolab.com/en-us").
 
 </details>
 
@@ -147,7 +147,7 @@ The path may differ on your system (different drive letter, program version, lan
 
 After diagnostics are completed, a report.zip file will be created. This file will be in the program's installation directory (it will open automatically once diagnostics finish).
 
-Please [send the resulting file to support](https://helpdesk.zennolab.com/ "https://helpdesk.zennolab.com/").
+Please [send the resulting file to support](https://helpdesk.zennolab.com/en-us "https://helpdesk.zennolab.com/en-us").
 
 </details>
 
@@ -172,6 +172,6 @@ The path may differ on your system (different drive letter, program version,)
 
 After diagnostics are completed, a report.zip file will be created. This file will be in the program's installation directory (it will open automatically once diagnostics finish).
 
-Please [send the resulting file to support](https://helpdesk.zennolab.com/ "https://helpdesk.zennolab.com/").
+Please [send the resulting file to support](https://helpdesk.zennolab.com/en-us "https://helpdesk.zennolab.com/en-us").
 
 </details>


### PR DESCRIPTION
## Summary

Two independent fixes for the English (EN) documentation of ZennoPoster, ZennoDroid, and CapMonster. Both are already on `dev` and target `main`. Total: 12 files changed, +87 / −15.

### 1. Helpdesk support locale in EN docs (11 files)

**Problem:** English docs linked the support portal to the Russian locale (`helpdesk.zennolab.com/ru`) or to a locale-less URL (`helpdesk.zennolab.com/`), so EN users landed on Russian support pages.

**Fix:** Replaced every `helpdesk.zennolab.com/ru` and locale-less `helpdesk.zennolab.com/` URL with `helpdesk.zennolab.com/en-us`, matching the locale logic already used in `src/components/UsefulLinks/index.jsx`.

**Coverage by product:**
- **ZennoDroid (7 files):** `Enterprise/BlueStacks.mdx`, `Enterprise/Connection.mdx`, `Enterprise/WelcomeEnterprise.mdx`, `get-started/Other_Settings.mdx`, `introduction/ZennoDroid.mdx`, `pm/Welcome_PM.mdx`, `pro-lite/WelcomeProLite.mdx`
- **ZennoPoster (3 files):** `Hello/Obtaining_Client_Status.mdx`, `Operating_Instructions.mdx`, `ZennoPoster/Problem_solving/Diagnostic_Report_with_Detailed_Log.mdx`
- **CapMonster (1 file):** `mcs/intro.mdx`

Also updated `/conversation/new` deep links and `title` (tooltip) attributes where present.

### 2. EN translations for ZennoPoster category index pages (1 file)

**Problem:** 9 ZennoPoster category index pages were missing `generated-index` translation keys in `i18n/en/docusaurus-plugin-content-docs-zennoposter/current.json`, so they fell back to Russian titles and descriptions.

**Fix:** Added 18 missing `generated-index` translation keys (title + description) for the following 9 categories: Tables, Project Delivery, Project Settings, Schedule Planner, ProjectMaker, ZennoPoster, История изменений ZennoPoster, ZennoPoster 7 — история изменений, ZennoPoster 5 — история изменений.

**Result:** EN category index pages now render proper English titles and descriptions instead of falling back to Russian.
