### PR TITLE
docs: fix links and improve LSPosed installation section (RU + EN)

### DIFF
--- a/docs/ZennoDroid/Enterprise/LSPosed.mdx
+++ b/docs/ZennoDroid/Enterprise/LSPosed.mdx
@@ -23,13 +23,15 @@ export const VideoSample = ({source}) => (
 _________________  
 ## Установка LSPosed Framework    
   
+Начиная с версии ZennoDroid 2.5.0.0, для установки модуля необходим телефон с [**Magisk**](https://github.com/topjohnwu/Magisk/releases/latest) и активным [**LSPosed Framework v2**](https://www.dropbox.com/scl/fo/bve4et0ilt6bocnbi7ba9/AI0JuEpsjOHkKKlYMgx9aM0?rlkey=je4fi8u0np6267i0e5iblsyu3&st=rlrsg76a&dl=0).  
+
 <details>
-<summary>Начиная с версии ZennoDroid 2.5.0.0, для установки модуля необходим телефон с [**Magisk**](https://github.com/topjohnwu/Magisk) и активным [**LSPosed Framework v2**](https://www.dropbox.com/scl/fo/bve4et0ilt6bocnbi7ba9/AI0JuEpsjOHkKKlYMgx9aM0?rlkey=je4fi8u0np6267i0e5iblsyu3&st=rlrsg76a&dl=0).</summary>  
+<summary>Активация Zygisk в Magisk</summary>
 
  ![Magisk](./assets/LSPosed/LSPosed_pic1.png) ![zygisk](./assets/LSPosed/LSPosed_pic2.png) 
 </details>   
 
-Актуальная официальная версия LSPosed распространяется через официальный [**Telegram канал**](https://t.me/LSPosed). Также последню версию LSPosed можно скачать по [**ссылке**](https://www.dropbox.com/scl/fo/bve4et0ilt6bocnbi7ba9/AI0JuEpsjOHkKKlYMgx9aM0?rlkey=je4fi8u0np6267i0e5iblsyu3&st=rlrsg76a&dl=0)
+Актуальная официальная версия LSPosed распространяется через официальный [**Telegram канал**](https://t.me/LSPosed). Также последнюю версию LSPosed можно скачать по [**ссылке**](https://www.dropbox.com/scl/fo/bve4et0ilt6bocnbi7ba9/AI0JuEpsjOHkKKlYMgx9aM0?rlkey=je4fi8u0np6267i0e5iblsyu3&st=rlrsg76a&dl=0)
 
 <details>
 <summary> Этот билд нужно скачать на телефон в папку **sdcard/Download/** и установить с помощью стандартного меню.</summary>  

--- a/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/LSPosed.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennodroid/current/Enterprise/LSPosed.mdx
@@ -17,14 +17,16 @@ export const VideoSample = ({source}) => (
 
 ## Description
 The ZennoDroid module is needed to spoof key device parameters: IMEI, Android ID, mobile operator, model, WiFi, Bluetooth, and others.
-:::info Important.
-Supported phones: Android 8.1-14. **Root access** is required for the module to work.
+:::info **Root access is required for the module to work**
+Supported phones: Android 8.1-16
 :::
 _________________
 ## Installing the LSPosed Framework
 
+Starting with ZennoDroid 2.5.0.0, you'll need a phone with [**Magisk**](https://github.com/topjohnwu/Magisk/releases/latest) and a working [**LSPosed Framework v2**](https://www.dropbox.com/scl/fo/bve4et0ilt6bocnbi7ba9/AI0JuEpsjOHkKKlYMgx9aM0?rlkey=je4fi8u0np6267i0e5iblsyu3&st=rlrsg76a&dl=0) to install the module.  
+
 <details>
-<summary>Starting with ZennoDroid 2.5.0.0, you'll need a phone with [**Magisk**](https://github.com/topjohnwu/Magisk) and a working [**LSPosed Framework v2**](https://www.dropbox.com/scl/fo/bve4et0ilt6bocnbi7ba9/AI0JuEpsjOHkKKlYMgx9aM0?rlkey=je4fi8u0np6267i0e5iblsyu3&st=rlrsg76a&dl=0) to install the module.</summary>  
+<summary>Enabling Zygisk in Magisk</summary>
 
 |   ![Magisk](./assets/LSPosed/LSPosed_pic1.png)   | ![zygisk](./assets/LSPosed/LSPosed_pic2.png) |
 | :--------: | :-------: |


### PR DESCRIPTION
## Changes

### LSPosed Framework
- Update Magisk link to point to latest release (`/releases/latest`) (RU + EN)
- Move version prerequisite note outside collapsed `<details>` block (RU + EN)
- Rename `<details>` summary to "Activating Zygisk in Magisk" (RU + EN)
- Update supported Android versions: 8.1–14 → 8.1–16 (EN)
- Fix typo in Russian text

**Stats:** 2 files changed, 9 insertions(+), 5 deletions(-)
