### PR TITLE
fix: show full titles and descriptions in table-of-contents cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .vs/
 docusaurus.config.js
 .*/
+*.log

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -355,6 +355,14 @@ a[class*='cardContainer'] {
   box-shadow: none;
 }
 
+/* Показываем названия и описания страниц в карточках оглавления полностью. */
+.theme-doc-card-title,
+.theme-doc-card-description {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+}
+
 @media (max-width: 436px) {
   .navbar__logo img {
     max-width: 180px;


### PR DESCRIPTION
Removed text truncation for `.theme-doc-card-title` and `.theme-doc-card-description` in `src/css/custom.css`, so long titles and descriptions in table-of-contents cards are now displayed in full instead of being clipped with an ellipsis.
