### PR TITLE
docs: remove nonexistent cookie export bulk action

### DIFF
--- a/docs/ZennoBrowser/main-feautures/structure_and_main_components.mdx
+++ b/docs/ZennoBrowser/main-feautures/structure_and_main_components.mdx
@@ -58,6 +58,5 @@ import DisclaimerNotice from '@site/src/components/DisclaimerNotice';
  - Замена прокси;
  - Перемещение в другую папку;
  - Управление тегами;
- - Экспорт cookie-файлов;
  - Массовая смена IP мобильных прокси;
  - Удаление профилей.

--- a/i18n/en/docusaurus-plugin-content-docs-zennobrowser/current/main-feautures/structure_and_main_components.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs-zennobrowser/current/main-feautures/structure_and_main_components.mdx
@@ -58,6 +58,5 @@ Organization and storage structure:
  - Replace proxy;
  - Move to another folder;
  - Manage tags;
- - Export cookies;
  - Bulk change of mobile proxy IP;
  - Delete profiles.


### PR DESCRIPTION
## Summary
Removed the "Export cookies" item from the bulk actions list (RU + EN), as this functionality does not exist in the product.
